### PR TITLE
Fixes URL host and hostname issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function RPC (src, dst, origin, methods) {
     else if (origin) {
         var link = document.createElement('a')
         link.setAttribute('href', origin);
-        this.origin = link.protocol + '//' + link.hostname;
+        this.origin = link.protocol + '//' + link.host;
     }
 
     this._sequence = 0;


### PR DESCRIPTION
We previously swapped `hostname` for `host` which I think was an error. The createElement approach returns the same as new URL.

```js
new URL('http://localhost:8080').host // "localhost:8080"

const link = document.createElement('a');
link.setAttribute('href', 'http://localhost:8080')
link.host // "localhost:8080"

new URL('http://localhost:80').host // "localhost"

const link = document.createElement('a');
link.setAttribute('href', 'http://localhost:80')
link.host // "localhost"
```

